### PR TITLE
QOL: locatie vóór vaknaam

### DIFF
--- a/lib/src/utils/background.dart
+++ b/lib/src/utils/background.dart
@@ -47,7 +47,7 @@ class Notifications {
     }
   }
 
-  String _lesString(Les les) => "${les.startTime} - ${les.endTime}: ${les.getName()}" + (les.location == null ? "" : " - ${les.location}");
+  String _lesString(Les les) => "${les.startTime} - ${les.endTime}: " + (les.location == null ? "" : "${les.location} - ") + "${les.getName()}";
 
   Future<void> _scheduleNotificationFor(Les lesson) async {
     Iterable<Les> day = lessons.where((les) => les.date == lesson.date);


### PR DESCRIPTION
**Probleem**
Op dit moment staat de locatie op een lagere prioriteit dan de naam van het vak, waardoor het lastiger is om in één oogopslag het juiste lokaal te zien. In de notificatie is deze meestal ook afgekapt:
> "11:05 - 11:50: netl - DOC - 6Vnetl3..."

**Oplossingen**
- [ ] In de agenda het lokaal vooraan de titel toevoegen en verwijderen uit de subtitel.
- [x] In notificaties het lokaal voor de naam van het vak plaatsen.