### PR TITLE
Inlog probleem vanwege een onvolledige code door een foutieve regex

### DIFF
--- a/lib/src/utils/login.dart
+++ b/lib/src/utils/login.dart
@@ -579,7 +579,7 @@ class MagisterLogin {
         "refresh_token": tempAccount.refreshToken,
       };
     } else {
-      String code = _tokenRegex.firstMatch(url).group(0);
+      String code = Uri.parse(url.replaceFirst("#", "?")).queryParameters["code"];
 
       Response res = await Dio().post(
         "https://accounts.magister.net/connect/token",


### PR DESCRIPTION
De gebruikte Regex (`var _tokenRegex = RegExp(r"\d{6}[\w-]{35}");`) haalde niet altijd de volledige code op. Nu gebeurd dat wel door middel van [queryParameters](https://api.flutter.dev/flutter/dart-core/Uri/queryParameters.html).

Dit probleem is ook vermeld in de Argo Discord-server:

> Het inloggen werkt ook niet meer. In de webview kan er geen toetsenbord getoond worden, en via de browser komt er een {error: invalid_grant} terug.
> ![image](https://user-images.githubusercontent.com/96647011/217864053-57260073-8fc2-4aeb-84a5-d3cbc68a8b8d.png)
> Kan zijn dat Magister weer bezig is, werkte namelijk wel op mijn account een week geleden.
