### PR TITLE
GitHub Actions 2 APK bestanden laten maken

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,11 +55,17 @@ jobs:
               run: flutter build apk --split-per-abi --dart-define=GITHUB_SHA=$GITHUB_SHA
 
             # Add File
-            - name: Export APK
+            - name: Export APK (Armeabi-v7a)
               uses: actions/upload-artifact@v3
               with:
                   name: release-apk
                   path: build/app/outputs/flutter-apk/app-armeabi-v7a-release.apk
+
+            - name: Export APK (Arm64-v8a)
+              uses: actions/upload-artifact@v3
+              with:
+                  name: release-apk
+                  path: build/app/outputs/flutter-apk/app-arm64-v8a-release.apk
 
             # Upload
 

--- a/README.md
+++ b/README.md
@@ -73,4 +73,4 @@ De auteurs zitten inmiddels niet meer op de middelbare school en daarom kunnen w
 
 Dit project is beschermd onder de Apache 2.0 license - Bekijk het [LICENSE](LICENSE) bestand voor details.
 
-Argo is geen onderdeel van of gerelateerd aan SchoolMaster B.V.
+Argo is geen onderdeel van of gerelateerd aan SchoolMaster B.V. 


### PR DESCRIPTION
Toen ik Argo wilde herinstalleren lukte dat niet omdat er geen APK bestand was voor de architectuur van mijn telefoon. Deze toevoeging zorgt ervoor dat beide architecturen in één ZIP bestand worden gezet. 